### PR TITLE
Fix script error when running `any` with no args

### DIFF
--- a/bin/any
+++ b/bin/any
@@ -1,4 +1,9 @@
 #!/bin/bash
 
 # http://www.commandlinefu.com/commands/view/13950
+if [ -z "$1" ]; then
+  echo "Usage: $0 PATTERN" >&2
+  exit 1
+fi
+
 ps aux | grep -E "[${1:0:1}]${1:1}|^USER" | grep -v "any $1"


### PR DESCRIPTION
## Summary
- handle missing arguments in `bin/any`

## Testing
- `bash -n bin/any`
- `./bin/any`
- `./bin/any bash | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_686adece26d0832592f69a4cc6cb2175